### PR TITLE
allow statistical input

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,8 @@ Optional:
  - `edgecolor` : string - The string color each edge bar will be plotted.
    Default : no edgecolor
  - `opening` : float - between 0.0 and 1.0, to control the space between each sector (1.0 for no space)
+ - `mean_values` : Bool - specify wind speed statistics with direction=specific mean wind speeds. If this flag is specified, var is expected to be an array of mean wind speeds corresponding to each entry in `direction`. These are used to generate a distribution of wind speeds assuming the distribution is Weibull with shape factor = 2.
+ - `weibull_factors` : Bool - specify wind speed statistics with direction=specific weibull scale and shape factors. If this flag is specified, var is expected to be of the form [[7,2], ...., [7.5,1.9]] where var[i][0] is the weibull scale factor and var[i][1] is the shape factor
 
 ###probability density function (pdf) and fitting Weibull distribution
 

--- a/windrose/windrose.py
+++ b/windrose/windrose.py
@@ -6,6 +6,7 @@
 import locale
 import matplotlib as mpl
 import numpy as np
+import random
 from matplotlib.projections.polar import PolarAxes
 from numpy.lib.twodim_base import histogram2d
 import matplotlib.pyplot as plt
@@ -214,7 +215,41 @@ class WindroseAxes(PolarAxes):
     def _init_plot(self, direction, var, **kwargs):
         """
         Internal method used by all plotting commands
+        direction : 1D array - directions the wind blows from, North centred
+        var : 1D array - values of the variable to compute. Typically the wind
+              speeds
         """
+
+        # if weibull factors are entered overwrite direction and var
+        if 'weibull_factors' in kwargs or 'mean_values' in kwargs:
+           if 'weibull_factors' in kwargs and 'mean_values' in kwargs:
+              raise TypeError("cannot specify both weibull_factors and mean_values") 
+           statistic_type = 'unset'
+           if 'weibull_factors' in kwargs:
+              statistic_type = 'weibull'
+              kwargs.pop('weibull_factors')
+           elif 'mean_values' in kwargs:
+              statistic_type = 'mean'
+              kwargs.pop('mean_values')
+           if 'frequency' not in kwargs:
+              raise TypeError("specify 'frequency' argument for statistical input")
+           windFrequencies = kwargs.pop('frequency')
+           if len(windFrequencies) != len(direction) or len(direction) != len(var):
+              if len(windFrequencies) != len(direction):
+                 raise TypeError("len(frequency) != len(direction)")
+              elif len(direction) != len(var):
+                 raise TypeError("len(frequency) != len(direction)")
+           windSpeeds = []
+           windDirections = []
+           for dbin in range(len(direction)):
+               for _ in range(int(windFrequencies[dbin] * 10000)):
+                   if statistic_type == 'weibull':
+                      windSpeeds.append(random.weibullvariate(var[dbin][0], var[dbin][1]))
+                   elif statistic_type=='mean':
+                      windSpeeds.append(random.weibullvariate(var[dbin] * 2 / np.sqrt(np.pi), 2))
+                   windDirections.append(direction[dbin]) 
+           var, direction = windSpeeds, windDirections
+
         # self.cla()
         kwargs.pop('zorder', None)
 


### PR DESCRIPTION
Users may only have statistical information about a wind rose. Often these statistics are summarized by direction-specific frequencies and Weibull scale/shape factors or mean wind seeds. The `weibul_factors` and `mean_values` arguments allows users to input the statistics, expecting the `direction` and `var` arguments to describe speed statistics for each direction.

Example usage:


    import urllib
    from windrose import WindroseAxes
    from matplotlib import pyplot as plt
    import numpy as np
    urllib.urlretrieve('https://raw.githubusercontent.com/WISDEM/FLORISSE/develop/test/input_files/windrose_amalia_directionally_averaged_speeds.txt', 'windrose_amalia_directionally_averaged_speeds.txt')
    fig = plt.figure(figsize=(12, 8), dpi=80, facecolor='w', edgecolor='w')
    ax = WindroseAxes(fig, [0.1, 0.1, 0.8, 0.8], axisbg='w')
    fig.add_axes(ax)
    windRose = np.loadtxt('windrose_amalia_directionally_averaged_speeds.txt')
    indexes = np.where(windRose[:, 1] > 0.1)
    windDirections = windRose[indexes[0], 0]
    windSpeeds = windRose[indexes[0], 1] * 2 / np.sqrt(np.pi) # convert from mean wind speed to weibull scale factor
    windFrequencies = windRose[indexes[0], 2]
    size  = len(windDirections)
    ax.box(windDirections, windSpeeds, frequency=windFrequencies, mean_values=1, bins=[15, 18, 20, 23, 25], nsector=72)
    #ax.box(windDirections, [[windSpeeds[i], 2] for i in range(len(windSpeeds))], frequency=windFrequencies, weibull_factors=1, bins=[15, 18, 20, 23, 25], nsector=72)
    ax.set_yticklabels([])
    plt.show()